### PR TITLE
Script to Detect Errors in Sorting Distance for Web

### DIFF
--- a/src/test/java/webproductobjects/LocationPage.java
+++ b/src/test/java/webproductobjects/LocationPage.java
@@ -1,0 +1,13 @@
+package webproductobjects;
+
+import org.openqa.selenium.WebDriver;
+
+public class LocationPage extends BasePage {
+	
+	public String distanceValuesXpath = "//div[@class='store-item__distance']/child::span";
+
+	public LocationPage(WebDriver driver) {
+		super(driver);
+	}
+
+}

--- a/src/test/java/webtestrunner/LandingTest.java
+++ b/src/test/java/webtestrunner/LandingTest.java
@@ -2,4 +2,6 @@ package webtestrunner;
 
 public class LandingTest extends Hooks {
 	
+	
+	
 }

--- a/src/test/java/webtestrunner/LocationTest.java
+++ b/src/test/java/webtestrunner/LocationTest.java
@@ -1,0 +1,43 @@
+package webtestrunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.testng.annotations.Test;
+
+import webproductobjects.LandingPage;
+import webproductobjects.LocationPage;
+
+public class LocationTest extends Hooks {
+
+	@Test
+	public void distanceLowToHighTest() throws Exception {
+		
+		//LandingPage landingPage = new LandingPage(driver);
+		LocationPage locationPage = new LocationPage(driver);
+		
+		//landingPage.click(landingPage.menuItems.get("location"));
+		Thread.sleep(10000);
+		
+		List<WebElement> distanceValuesXpath = driver.findElements(By.xpath(locationPage.distanceValuesXpath));
+		
+		//Convert all WebElements to Double values
+		List<Double> distanceValues = new ArrayList<Double>();
+		for(int i = 1; i < distanceValuesXpath.size(); i++) {
+			String str = distanceValuesXpath.get(i).getText().replaceAll("[a-zA-Z ]", "");
+			double temp = Double.parseDouble(str);
+			distanceValues.add(temp);
+		}
+		
+		//Check each distance value with proceeding to see if it is less than the proceeding value
+		for(int i = 1; i < distanceValues.size() - 1; i++) {
+			if(distanceValues.get(i) > distanceValues.get(i + 1)) {
+				throw new Exception("Distance Error. Not ordered from closest to furthest:" + i);
+			}
+		}
+		
+	}
+	 
+}

--- a/src/test/java/webtestrunner/SignInTest.java
+++ b/src/test/java/webtestrunner/SignInTest.java
@@ -7,8 +7,8 @@ import webproductobjects.signInPage;
 
 public class SignInTest extends Hooks {
 	
-	@Test
-	public void test() throws InterruptedException {
+	@Test(enabled=false)
+	public void signIn() throws InterruptedException {
 		
 		try {
 			Thread.sleep(5000);


### PR DESCRIPTION
Script is to detect errors in the distance sort in Location tab. Checks for any Dunkin locations that are not sorted from closest to furthers (ie: Shows location A, 2 miles away, is close than location B, 1 mile away)

Locations Page
![Screen Shot 2021-10-26 at 2 48 40 PM](https://user-images.githubusercontent.com/48166452/138942165-6ea55973-c88c-4bcc-9ab2-b952602d410c.png)

### Code

LocationTest.java
![Screen Shot 2021-10-26 at 2 49 17 PM](https://user-images.githubusercontent.com/48166452/138942249-9a05b538-bace-48ba-add4-1ff72180a637.png)

LocationPage.java
![Screen Shot 2021-10-26 at 2 50 10 PM](https://user-images.githubusercontent.com/48166452/138942377-65b06a0c-aa61-48bf-9f06-3c4652fd994c.png)


